### PR TITLE
Add filter for skipping validation of catalog visibility

### DIFF
--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -182,6 +182,18 @@ class ProductValidator {
 	 */
 	protected function validate_product_visibility() {
 		$product = $this->product_parent ? $this->product_parent : $this->product;
+		
+		/**
+		 * Filters whether the product must be visible in catalog and search results to be validated.
+		 *
+		 * @since 2.6.5
+		 *
+		 * @param boolean $enabled default true
+		 * @param \WC_Product $product product object
+		 */
+		if ( ! apply_filters( 'wc_facebook_validate_product_visibility', true, $product ) ) {
+			return;
+		}
 
 		if ( 'visible' !== $product->get_catalog_visibility() ) {
 			throw new ProductExcludedException( __( 'Product is hidden from catalog and search.', 'facebook-for-woocommerce' ) );


### PR DESCRIPTION
Add filter "wc_facebook_validate_product_visibility" to optionally skip the validation of product visibility in catalog and search results.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Changes proposed in this Pull Request:
Some plugins like "WooCommerce Single Variations" by IconicWP allow single variations to show up in the catalog. Therefore a common use case is to show a handful of variations in the catalog and hide the parent product from catalog and search results. This prevents the variable product altogether from syncing as the product is validated and part of this validation is whether the product is visible in catalog and search results.

As the hard criteria whether a product is included / synced is the post status and additional exclusion rules by taxonomy, the catalog visibility should be optional.


### How to test the changes in this Pull Request:
1. Exclude a product from catalog in product edit screen
2. Sync to Facebook, see the product is not synced
3. Add e.g. `add_filter('wc_facebook_validate_product_visibility', '__return_false', 10);` to functions.php
4. Sync to Facebook, confirm the product is synced again

### Changelog entry

> New - Add filter "wc_facebook_validate_product_visibility"
