### PR TITLE
Fix - Sync stock quantity when available

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -724,9 +724,15 @@ class WC_Facebook_Product {
 			$product_data = $this->apply_enhanced_catalog_fields_from_attributes( $product_data, $google_product_category );
 		}
 
-		// add the Commerce values (only stock quantity for the moment)
-		if ( Products::is_product_ready_for_commerce( $this->woo_product ) ) {
+		// Add stock quantity if the product or variant is stock managed.
+		// In case if variant is not stock managed but parent is, fallback on parent value
+		if ( $this->woo_product->managing_stock() ) {
 			$product_data['quantity_to_sell_on_facebook'] = (int) max( 0, $this->woo_product->get_stock_quantity() );
+		} else if ($this->woo_product->is_type( 'variation' )) {
+			$parent_product = wc_get_product( $this->woo_product->get_parent_id());
+			if ( $parent_product && $parent_product->managing_stock()) {	
+				$product_data['quantity_to_sell_on_facebook'] = (int) max( 0, $parent_product->get_stock_quantity() );
+			}
 		}
 
 		// Only use checkout URLs if they exist.

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -725,12 +725,12 @@ class WC_Facebook_Product {
 		}
 
 		// Add stock quantity if the product or variant is stock managed.
-		// In case if variant is not stock managed but parent is, fallback on parent value
+		// In case if variant is not stock managed but parent is, fallback on parent value.
 		if ( $this->woo_product->managing_stock() ) {
 			$product_data['quantity_to_sell_on_facebook'] = (int) max( 0, $this->woo_product->get_stock_quantity() );
-		} else if ($this->woo_product->is_type( 'variation' )) {
-			$parent_product = wc_get_product( $this->woo_product->get_parent_id());
-			if ( $parent_product && $parent_product->managing_stock()) {	
+		} else if ( $this->woo_product->is_type( 'variation' ) ) {
+			$parent_product = wc_get_product( $this->woo_product->get_parent_id() );
+			if ( $parent_product && $parent_product->managing_stock() ) {	
 				$product_data['quantity_to_sell_on_facebook'] = (int) max( 0, $parent_product->get_stock_quantity() );
 			}
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This change suggests to always sync to Meta the stock quantity when it is available.

### Screenshots:
N/A (no changes to UI/UX)

### Detailed test instructions:
1. Run new tests
./vendor/bin/phpunit --filter test_quantity_to_sell_on_facebook_when_manage_stock_is_on_for_simple_product
./vendor/bin/phpunit --filter test_quantity_to_sell_on_facebook_when_manage_stock_is_off_for_simple_product
./vendor/bin/phpunit --filter test_quantity_to_sell_on_facebook_when_manage_stock_is_on_for_variable_product
./vendor/bin/phpunit --filter test_quantity_to_sell_on_facebook_when_manage_stock_is_off_for_variable_product_and_off_for_parent
./vendor/bin/phpunit --filter test_quantity_to_sell_on_facebook_when_manage_stock_is_off_for_variable_product_and_on_for_parent

2. Run all tests
npm run test:php

3. Manual testing. I tested this in the locally hosted WP WooCommerce website and checked logs on Meta side to verify the request is being sent with the "quantity_to_sell_on_facebook" populated correctly. Tested on both simple and variable products.

### Changelog entry

> Fix - Sync stock quantity when available