### PR TITLE
feat: Add custom fields to product data structure

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -662,6 +662,31 @@ class WC_Facebook_Product {
 			$brand = wp_strip_all_tags( WC_Facebookcommerce_Utils::get_store_name() );
 		}
 
+		$custom_fields = array(
+			'description' => '',
+			'price' => '',
+			'image_url' => ''
+		);
+
+		// check if fb specific description exists
+		$fb_description = get_post_meta($this->id, self::FB_PRODUCT_DESCRIPTION, true);
+		if (!empty($fb_description)){
+			$custom_fields['description'] = $fb_description;
+		}
+		
+		// check if fb specific price exists
+		$fb_price = get_post_meta($this->id, self::FB_PRODUCT_PRICE, true);
+		if (!empty($fb_price)){
+			$custom_fields['price'] = $fb_price;
+			
+		}
+		
+		// check if fb specific image url exists
+		$fb_image = get_post_meta($this->id, self::FB_PRODUCT_IMAGE, true);
+		if (!empty($fb_image)){
+			$custom_fields['image_url'] = $fb_image;
+		}
+
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
 			$product_data = array(
 				'title'                 => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
@@ -675,6 +700,7 @@ class WC_Facebook_Product {
 				'price'                 => $this->get_fb_price( true ),
 				'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 				'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
+				'custom_fields'			=> $custom_fields
 			);
 			$product_data   = $this->add_sale_price( $product_data, true );
 			$gpc_field_name = 'google_product_category';
@@ -706,6 +732,7 @@ class WC_Facebook_Product {
 				'currency'              => get_woocommerce_currency(),
 				'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 				'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
+				'custom_fields'			=> $custom_fields
 			);
 
 			if ( self::PRODUCT_PREP_TYPE_NORMAL !== $type_to_prepare_for && ! empty( $video_urls ) ) {

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -5,6 +5,29 @@ declare(strict_types=1);
 class fbproductTest extends WP_UnitTestCase {
 	private $parent_fb_product;
 
+	/** @var \WC_Product_Simple */
+	protected $product;
+	
+	/** @var \WC_Facebook_Product */
+	protected $fb_product;
+	
+	public function setUp(): void {
+		parent::setUp();
+
+		// creating a simple product
+		$this->product = new \WC_Product_Simple();
+		$this->product->set_name('Test Product');
+		$this->product->set_regular_price('10');
+		$this->product->save();
+
+		$this->fb_product = new WC_Facebook_Product($this->product);
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->product->delete(true);
+	}
+
 	/**
 	 * Test it gets description from post meta.
 	 * @return void
@@ -359,5 +382,69 @@ class fbproductTest extends WP_UnitTestCase {
 		$data = $fb_product->prepare_product();
 
 		$this->assertEquals(isset($data['gtin']), false);
+	}
+
+	public function test_prepare_product_with_default_fields(){
+		// test when no fb specific fields are set
+		$product_data = $this->fb_product->prepare_product();
+
+		$this->assertArrayHasKey('custom_fields', $product_data);
+		$this->assertEquals('', $product_data['custom_fields']['description']);
+		$this->assertEquals('', $product_data['custom_fields']['price']);
+		$this->assertEquals('', $product_data['custom_fields']['image_url']);
+
+	}
+	
+	public function test_prepare_product_with_custom_fields(){
+		// Set facebook specific fields
+		$fb_description = 'Facebook specific description';
+		$fb_price = '15';
+		$fb_image = 'https:example.com/fb-image.jpg';
+
+		update_post_meta($this->product->get_id(), WC_Facebook_Product::FB_PRODUCT_DESCRIPTION, $fb_description);
+		update_post_meta($this->product->get_id(), WC_Facebook_Product::FB_PRODUCT_PRICE, $fb_price);
+		update_post_meta($this->product->get_id(), WC_Facebook_Product::FB_PRODUCT_IMAGE, $fb_image);
+		
+		$product_data = $this->fb_product->prepare_product();
+
+		$this->assertArrayHasKey('custom_fields', $product_data);
+		$this->assertEquals($fb_description, $product_data['custom_fields']['description']);
+		$this->assertEquals($fb_price, $product_data['custom_fields']['price']);
+		$this->assertEquals($fb_image, $product_data['custom_fields']['image_url']);
+
+	}
+	
+	public function test_prepare_product_with_mixed_fields(){
+		// Set only facebook description
+		$fb_description = 'Facebook specific description';
+
+		update_post_meta($this->product->get_id(), WC_Facebook_Product::FB_PRODUCT_DESCRIPTION, $fb_description);
+		
+		$product_data = $this->fb_product->prepare_product();
+
+		$this->assertArrayHasKey('custom_fields', $product_data);
+		$this->assertEquals($fb_description, $product_data['custom_fields']['description']);
+		$this->assertEquals('', $product_data['custom_fields']['price']);
+		$this->assertEquals('', $product_data['custom_fields']['image_url']);
+
+	}
+	
+	public function test_prepare_product_items_batch(){
+		// Test the PRODUCT_PREP_TYPE_ITEMS_BATCH preparation type
+		$fb_description = 'Facebook specific description';
+
+		update_post_meta($this->product->get_id(), WC_Facebook_Product::FB_PRODUCT_DESCRIPTION, $fb_description);
+		
+		$product_data = $this->fb_product->prepare_product(null, WC_Facebook_Product::PRODUCT_PREP_TYPE_ITEMS_BATCH);
+
+		$this->assertArrayHasKey('custom_fields', $product_data);
+		$this->assertEquals($fb_description, $product_data['custom_fields']['description']);
+		$this->assertEquals('', $product_data['custom_fields']['price']);
+		$this->assertEquals('', $product_data['custom_fields']['image_url']);
+
+		// Also verify the main product data structure for items batch
+		$this->assertArrayHasKey('title', $product_data);
+		$this->assertArrayHasKey('description', $product_data);
+		$this->assertArrayHasKey('image_link', $product_data);
 	}
 }


### PR DESCRIPTION
# Add custom fields to Product Data Structure

## Overview
This PR introduces a new `custom_fields` to the product data structure 

## Changes
- Added `custom_fields` object containing 
-`description` 
-`price` 
-`image_url` 

- Fields remain empty when using WooCommerce default values
- Fields are populated when Facebook-specific overrides are present

## Screenshots 
- None required