### PR TITLE
Fix Product Syncing via Feeds

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -529,6 +529,15 @@ class API extends Base {
 		return $this->perform_request( $request );
 	}
 
+	/**
+	 * TODO
+	 */
+	public function create_upload( string $product_feed_id, array $data ) {
+		$request = new API\ProductCatalog\ProductFeedUploads\Create\Request( $product_feed_id, $data );
+		$this->set_response_handler( API\ProductCatalog\ProductFeedUploads\Create\Response::class );
+		return $this->perform_request( $request );
+	}
+
 
 	/**
 	 * @param string $external_merchant_settings_id

--- a/includes/API.php
+++ b/includes/API.php
@@ -517,7 +517,10 @@ class API extends Base {
 	}
 
 	/**
-	 * TODO
+	 * @param string $product_catalog_id Facebook Product Catalog ID.
+	 * @return Response
+	 * @throws ApiException
+	 * @throws API\Exceptions\Request_Limit_Reached
 	 */
 	public function create_feed( string $product_catalog_id, array $data ) {
 		$request = new API\ProductCatalog\ProductFeeds\Create\Request( $product_catalog_id, $data );
@@ -539,7 +542,10 @@ class API extends Base {
 	}
 
 	/**
-	 * TODO
+	 * @param string $product_feed_id Facebook Product Feed ID.
+	 * @return Response
+	 * @throws ApiException
+	 * @throws API\Exceptions\Request_Limit_Reached
 	 */
 	public function create_upload( string $product_feed_id, array $data ) {
 		$request = new API\ProductCatalog\ProductFeedUploads\Create\Request( $product_feed_id, $data );

--- a/includes/API.php
+++ b/includes/API.php
@@ -516,6 +516,15 @@ class API extends Base {
 		return $this->perform_request( $request );
 	}
 
+	/**
+	 * TODO
+	 */
+	public function create_feed( string $product_catalog_id, array $data ) {
+		$request = new API\ProductCatalog\ProductFeeds\Create\Request( $product_catalog_id, $data );
+		$this->set_response_handler( API\ProductCatalog\ProductFeeds\Create\Response::class );
+		return $this->perform_request( $request );
+	}
+
 
 	/**
 	 * @param string $product_feed_upload_id

--- a/includes/API/ProductCatalog/ProductFeedUploads/Create/Request.php
+++ b/includes/API/ProductCatalog/ProductFeedUploads/Create/Request.php
@@ -1,0 +1,25 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Create;
+
+use WooCommerce\Facebook\API\Request as ApiRequest;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Request object for Product Catalog > Product Feed Upload > Create Graph Api.
+ *
+ * @link https://developers.facebook.com/docs/marketing-api/reference/product-feed/uploads/#Creating
+ */
+class Request extends ApiRequest {
+
+	/**
+	 * @param string $product_feed_id Facebook Product Feed ID.
+	 * @param array  $data Facebook Product Feed Data.
+	 */
+	public function __construct( string $product_feed_id, array $data ) {
+		parent::__construct( "/{$product_feed_id}/uploads", 'POST' );
+		parent::set_data( $data );
+	}
+}

--- a/includes/API/ProductCatalog/ProductFeedUploads/Create/Response.php
+++ b/includes/API/ProductCatalog/ProductFeedUploads/Create/Response.php
@@ -1,0 +1,16 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\Facebook\API\ProductCatalog\ProductFeedUploads\Create;
+
+use WooCommerce\Facebook\API\Response as ApiResponse;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Response object for Product Catalog > Product Feed Upload > Create Graph Api.
+ *
+ * @link https://developers.facebook.com/docs/marketing-api/reference/product-feed/uploads/#Creating
+ * @property-read array $data Facebook Product Feeds Upload.
+ */
+class Response extends ApiResponse {}

--- a/includes/API/ProductCatalog/ProductFeeds/Read/Request.php
+++ b/includes/API/ProductCatalog/ProductFeeds/Read/Request.php
@@ -18,6 +18,6 @@ class Request extends ApiRequest {
 	 * @param string $product_feed_id Facebook Product Feed ID.
 	 */
 	public function __construct( string $product_feed_id ) {
-		parent::__construct( "/{$product_feed_id}/?fields=created_time,latest_upload,product_count,schedule,update_schedule", 'GET' );
+		parent::__construct( "/{$product_feed_id}/?fields=created_time,latest_upload,product_count,schedule,update_schedule,name", 'GET' );
 	}
 }

--- a/includes/Jobs/GenerateProductFeed.php
+++ b/includes/Jobs/GenerateProductFeed.php
@@ -35,6 +35,8 @@ class GenerateProductFeed extends AbstractChainedJob {
 		$feed_handler = new \WC_Facebook_Product_Feed();
 		$feed_handler->rename_temporary_feed_file_to_final_feed_file();
 		facebook_for_woocommerce()->get_tracker()->save_batch_generation_time();
+
+		do_action('wc_facebook_feed_generation_completed');
 	}
 
 	/**

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -39,7 +39,7 @@ class Feed {
 	/** @var string the WordPress option name where the secret included in the feed URL is stored */
 	const OPTION_FEED_URL_SECRET = 'wc_facebook_feed_url_secret';
 
-	// TODO: add description
+	/** @var string the feed name for creating a new feed by this plugin */
 	const FEED_NAME = 'Product Feed by Facebook for WooCommerce plugin. DO NOT DELETE.';
 
 	/**
@@ -180,7 +180,7 @@ class Feed {
 		 *
 		 * @param int $interval the frequency with which the product feed data is generated, in seconds. Defaults to every 15 minutes.
 		 */
-		$interval = apply_filters( 'wc_facebook_feed_generation_interval', HOUR_IN_SECONDS );
+		$interval = apply_filters( 'wc_facebook_feed_generation_interval', DAY_IN_SECONDS );
 		if ( ! as_next_scheduled_action( self::GENERATE_FEED_ACTION ) ) {
 			as_schedule_recurring_action( time(), max( 2, $interval ), self::GENERATE_FEED_ACTION, array(), facebook_for_woocommerce()->get_id_dasherized() );
 		}
@@ -188,7 +188,9 @@ class Feed {
 
 
 	/**
-	 * TODO: description and signiture
+	 * Sends request to Meta to start a one-time feed file upload session.
+	 *
+	 * @internal
 	 */
 	public function send_request_to_upload_feed() {
 		$feed_id = self::retrieve_or_create_integration_feed_id();
@@ -209,7 +211,11 @@ class Feed {
 	}
 
 	/**
-	 * TODO: description and signiture
+	 * Retrieves or creates an integration feed ID
+	 * 
+	 * @return		string the integration feed ID
+	 *
+	 * @internal
 	 */
 	public function retrieve_or_create_integration_feed_id() {
 		// Step 1 - Get feed ID if it is already available in local cache
@@ -243,7 +249,13 @@ class Feed {
 	}
 
 	/**
-	 * TODO: description and signiture
+	 * Validates that provided feed ID still exists on the Meta side
+	 *
+	 * @param 		string $feed_id the feed ID
+	 * 
+	 * @return		bool true if the feed ID is valid
+	 * 
+	 * @internal
 	 */
 	private function validate_feed_exists($feed_id) {
 		$catalog_id = facebook_for_woocommerce()->get_integration()->get_product_catalog_id();
@@ -269,7 +281,12 @@ class Feed {
 	}
 
 	/**
-	 * TODO: description and signiture
+	 * Queries existing feeds for the integration catalog and filters
+	 * the plugin integration feed ID
+	 * 
+	 * @return		string the integration feed ID
+	 * 
+	 * @internal
 	 */
 	private function query_and_filter_integration_feed_id() {
 		$catalog_id = facebook_for_woocommerce()->get_integration()->get_product_catalog_id();
@@ -328,6 +345,13 @@ class Feed {
 		return '';
 	}
 
+	/**
+	 * Makes a request to Meta to create a new feed
+	 * 
+	 * @return		string the integration feed ID
+	 * 
+	 * @internal
+	 */
 	private function create_feed_id() {
 		try {
 			$catalog_id = facebook_for_woocommerce()->get_integration()->get_product_catalog_id();

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -766,10 +766,15 @@ class WC_Facebook_Product {
 		if ( self::PRODUCT_PREP_TYPE_FEED !== $type_to_prepare_for ) {
 			$this->prepare_variants_for_item( $product_data );
 		} elseif (
-		WC_Facebookcommerce_Utils::is_all_caps( $product_data['description'] )
+			WC_Facebookcommerce_Utils::is_all_caps( $product_data['description'] )
 		) {
 			$product_data['description'] =
 			mb_strtolower( $product_data['description'] );
+		}
+
+		// Set feed specific data
+		if ( self::PRODUCT_PREP_TYPE_FEED === $type_to_prepare_for ) {
+			$product_data['woo_product_id'] = $this->woo_product->get_id();
 		}
 
 		/**

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -59,6 +59,8 @@ class WC_Facebook_Product_Feed {
 
 			\WC_Facebookcommerce_Utils::log( 'Product feed file generated' );
 
+			do_action('wc_facebook_feed_generation_completed');
+
 		} catch ( \Exception $exception ) {
 
 			\WC_Facebookcommerce_Utils::log( $exception->getMessage() );

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -28,7 +28,6 @@ class WC_Facebook_Product_Feed {
 	const FILE_NAME                      = 'product_catalog_%s.csv';
 	const FACEBOOK_CATALOG_FEED_FILENAME = 'fae_product_catalog.csv';
 	const FB_ADDITIONAL_IMAGES_FOR_FEED  = 5;
-	const FEED_NAME                      = 'Initial product sync from WooCommerce. DO NOT DELETE.';
 	const FB_PRODUCT_GROUP_ID            = 'fb_product_group_id';
 	const FB_VISIBILITY                  = 'fb_visibility';
 
@@ -376,7 +375,7 @@ class WC_Facebook_Product_Feed {
 		return 'id,title,description,image_link,link,product_type,' .
 		'brand,price,availability,item_group_id,checkout_url,' .
 		'additional_image_link,sale_price_effective_date,sale_price,condition,' .
-		'visibility,gender,color,size,pattern,google_product_category,default_product,variant,gtin' . PHP_EOL;
+		'visibility,gender,color,size,pattern,google_product_category,default_product,variant,gtin,quantity_to_sell_on_facebook,woo_product_id' . PHP_EOL;
 	}
 
 
@@ -523,7 +522,9 @@ class WC_Facebook_Product_Feed {
 		static::get_value_from_product_data( $product_data, 'google_product_category' ) . ',' .
 		static::get_value_from_product_data( $product_data, 'default_product' ) . ',' .
 		static::get_value_from_product_data( $product_data, 'variant' ) . ',' .
-		static::get_value_from_product_data( $product_data, 'gtin' ) . PHP_EOL;
+		static::get_value_from_product_data( $product_data, 'gtin' ) . ',' .
+		static::get_value_from_product_data( $product_data, 'quantity_to_sell_on_facebook' ) . ',' .
+		static::get_value_from_product_data( $product_data, 'woo_product_id' ) . PHP_EOL;
 	}
 
 	private static function format_additional_image_url( $product_image_urls ) {

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -376,7 +376,7 @@ class WC_Facebook_Product_Feed {
 		return 'id,title,description,image_link,link,product_type,' .
 		'brand,price,availability,item_group_id,checkout_url,' .
 		'additional_image_link,sale_price_effective_date,sale_price,condition,' .
-		'visibility,gender,color,size,pattern,google_product_category,default_product,variant' . PHP_EOL;
+		'visibility,gender,color,size,pattern,google_product_category,default_product,variant,gtin' . PHP_EOL;
 	}
 
 
@@ -522,7 +522,8 @@ class WC_Facebook_Product_Feed {
 		static::get_value_from_product_data( $product_data, 'pattern' ) . ',' .
 		static::get_value_from_product_data( $product_data, 'google_product_category' ) . ',' .
 		static::get_value_from_product_data( $product_data, 'default_product' ) . ',' .
-		static::get_value_from_product_data( $product_data, 'variant' ) . PHP_EOL;
+		static::get_value_from_product_data( $product_data, 'variant' ) . ',' .
+		static::get_value_from_product_data( $product_data, 'gtin' ) . PHP_EOL;
 	}
 
 	private static function format_additional_image_url( $product_image_urls ) {

--- a/tests/Unit/ApiTest.php
+++ b/tests/Unit/ApiTest.php
@@ -715,4 +715,63 @@ class ApiTest extends WP_UnitTestCase {
 			$response->data
 		);
 	}
+
+	/**
+	 * Tests create feed request to Facebook.
+	 *
+	 * @return void
+	 * @throws ApiException In case of network request error.
+	 */
+	public function test_create_feed_request() {
+		$facebook_product_catalog_id = '726635365295186';
+
+		$data = [
+			'name' => "Test feed name.",
+		];
+
+		$response = function( $result, $parsed_args, $url ) use ( $facebook_product_catalog_id ) {
+			$this->assertEquals( 'POST', $parsed_args['method'] );
+			$this->assertEquals( "{$this->endpoint}{$this->version}/{$facebook_product_catalog_id}/product_feeds", $url );
+			return [
+				'body'     => '{"id":"1068839467367301"}',
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+			];
+		};
+		add_filter( 'pre_http_request', $response, 10, 3 );
+
+		$response_feed = $this->api->create_feed( $facebook_product_catalog_id, $data );
+
+		$this->assertEquals( '1068839467367301', $response_feed['id'] );
+	}
+
+	/**
+	 * Tests create feed upload request to Facebook.
+	 *
+	 * @return void
+	 * @throws ApiException In case of network request error.
+	 */
+	public function test_create_upload_request() {
+		$product_feed_id = '1068839467367301';
+
+		$data = [
+			'url' => 'http://example.com/?wc-api=wc_facebook_get_feed_data&secret=c4b8c3c46145aac6519e3f8a28bc86f2',
+		];
+
+		$response = function( $result, $parsed_args, $url ) use ( $product_feed_id ) {
+			$this->assertEquals( 'POST', $parsed_args['method'] );
+			$this->assertEquals( "{$this->endpoint}{$this->version}/{$product_feed_id}/uploads", $url );
+			return [
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+			];
+		};
+		add_filter( 'pre_http_request', $response, 10, 3 );
+
+		$this->api->create_upload( $product_feed_id, $data );
+	}
 }

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -360,4 +360,31 @@ class fbproductTest extends WP_UnitTestCase {
 
 		$this->assertEquals(isset($data['gtin']), false);
 	}
+
+	/**
+	 * Test woo_product_id is added for feeds
+	 * @return void
+	 */
+	public function test_woo_product_id_is_set_for_feeds() {
+		$woo_product = WC_Helper_Product::create_simple_product();
+		
+		$fb_product = new \WC_Facebook_Product( $woo_product );
+		$data = $fb_product->prepare_product( null, WC_Facebook_Product::PRODUCT_PREP_TYPE_FEED );
+		// $data = $fb_product->prepare_product( );
+
+		$this->assertEquals( $data['woo_product_id'], $woo_product->get_id() );
+	}
+
+	/**
+	 * Test woo_product_id is not added for Batch API
+	 * @return void
+	 */
+	public function test_woo_product_id_is_unset_for_batch_api() {
+		$woo_product = WC_Helper_Product::create_simple_product();
+		
+		$fb_product = new \WC_Facebook_Product( $woo_product );
+		$data = $fb_product->prepare_product( null, WC_Facebook_Product::PRODUCT_PREP_TYPE_ITEMS_BATCH );
+
+		$this->assertEquals(isset($data['woo_product_id']), false);
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The current state of the product syncing via Feeds is broken - while plugin code base has business logic to generate feed file daily and serve the feed file on request, there is no logic for triggering a feed one time upload. 

In this PR I am suggesting the following fixes to unblock product sync via feeds:

1. Trigger a daily feed upload sessions.

      - Sending a one time  create feed upload request to Meta would happen on feed file generation completion (this is to ensure we upload as feed file fresh data as possible).
      - Added logic of choosing or creating the correct feed to which such feed upload would happen. This included local caching of the integrated feed ID, validating it is valid, choosing a feed from catalog or creating a new one.  

2. Update Feed file content by:

      - Adding `GTIN` to the feed file
      - Adding `quantity_to_sell_on_facebook` to the feed file
      - Adding `woo_product_id` to the feed file. This is to resolve any ambiguity of what is the woo id if needed due to retailer_id is a construct of both `woo_product_id` and `sku`.
 


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Unit Tests
  A. Run new tests:
      - `./vendor/bin/phpunit --filter ApiTest`
      - `./vendor/bin/phpunit --filter fbproductTest`
  B. Run all tests: 
      - `npm run test:php `
2. Manual Tests.
      - Steps were added via an internal dogfooding doc and requires access to Meta internal tools to validate feed upload sessions status. 

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

Fix - Fixed feeds by requesting a feed file upload session after feed file is generated and added missing new fields to the feed file.


>
